### PR TITLE
Fix error when file content is not set

### DIFF
--- a/src/controllers/contents/post.ts
+++ b/src/controllers/contents/post.ts
@@ -19,6 +19,10 @@ export async function createContent(req: Request, res: Response, _next: NextFunc
     return res.error(...messages.errors.noFileProvided);
 
   const content = Array.isArray(req.files.content) ? req.files.content[0] : req.files.content;
+
+  if (!content)
+    return res.error(...messages.errors.noFileProvided);
+
   try {
     const application = await Application.findById(req.application._id);
 


### PR DESCRIPTION
This PR checks whether the received files contain the `content` object before using it and causing errors.